### PR TITLE
Middleware: implement cache middleware.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Cache Middleware
+
 ## [1.0.0] - 2017-12-05
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LINTERS=\
 	ineffassign \
 	deadcode
 
-ci: $(LINTERS) test
+ci: $(LINTERS) test benchmark
 
 .PHONY: ci
 
@@ -31,15 +31,19 @@ vendor:
 # Test and linting
 #################################################
 
-test: vendor $(GENERATED_NAMING_FILES)
-	@CGO_ENABLED=0 go test -v $$(go list ./... | grep -v vendor)
+test: vendor
+	@CGO_ENABLED=0 go test -v
+
+# Make sure ulimit is high enough. This might cause issues otherwise.
+benchmark: vendor
+	@CGO_ENABLED=0 go test -v -run=XXX -bench=.
 
 lint: vendor $(LINTERS)
 
 METALINT=gometalinter --tests --disable-all --vendor --deadline=5m -s data \
 	 ./... --enable
 
-$(LINTERS): vendor $(GENERATED_NAMING_FILES)
+$(LINTERS): vendor
 	$(METALINT) $@
 
 .PHONY: $(LINTERS) test

--- a/README.md
+++ b/README.md
@@ -147,3 +147,31 @@ present, one where it isn't).
   }
 }
 ```
+
+## Middlewares
+
+We've included a set of standard middlewares that can be useful for general use.
+
+### Cache
+
+The cache middleware allows you to cache a response for a specific duration.
+This prevents the health check to overload due to different sources asking for
+the health status. This is especially useful when the health checks are used to
+check the health of other services as well.
+
+To use this middleware, simply add it to the chain:
+
+```go
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := healthz.NewHandlerWithMiddleware(
+		mux,
+		healthz.CacheMiddleware(5*time.Second),
+	)
+	http.ListenAndServe(":3000", handler)
+}
+```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![GitHub release](https://img.shields.io/github/tag/manifoldco/healthz.svg?label=latest)](https://github.com/manifoldco/healthz/releases)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/manifoldco/healthz)
-[![Travis](https://img.shields.io/travis/manifoldco/healthz/master.svg)](https://travis-ci.org/manifoldco/healthz)
+[![Build Status](https://travis-ci.org/manifoldco/healthz.svg?branch=master)](https://travis-ci.org/manifoldco/healthz)
 [![Go Report Card](https://goreportcard.com/badge/github.com/manifoldco/healthz)](https://goreportcard.com/report/github.com/manifoldco/healthz)
 [![License](https://img.shields.io/badge/license-BSD-blue.svg)](./LICENSE.md)
 

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -15,7 +15,8 @@ var Endpoint = "/_healthz"
 
 var healthCheckTests = map[string]TestFunc{}
 
-type middlewareFunc func(http.Handler) http.Handler
+// MiddlewareFunc represents a function that acts as middleware.
+type MiddlewareFunc func(http.Handler) http.Handler
 
 // TestFunc represents a function which will be executed when we run the health
 // check endpoint.
@@ -64,7 +65,7 @@ func NewHandler(dh http.Handler) http.Handler {
 
 // NewHandlerWithMiddleware wraps the given handler with a new health endpoint.
 // This health endpoint will be wrapped in the provided middleware.
-func NewHandlerWithMiddleware(dh http.Handler, mw ...middlewareFunc) http.Handler {
+func NewHandlerWithMiddleware(dh http.Handler, mw ...MiddlewareFunc) http.Handler {
 	var handler http.Handler
 	h := http.NewServeMux()
 

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,97 @@
+package healthz
+
+import (
+	"bytes"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// CacheMiddleware allows the health checks to be cached for a specified
+// duration. This means that subsequent calls will return the cached response
+// for all checks within a timespan of the given time.Duration.
+// When an error occurs writing the cached data to the response, this will
+// panic.
+func CacheMiddleware(d time.Duration) MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		h := &cacheHandler{
+			duration: d,
+			lastTick: time.Now(),
+		}
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if h.shouldCapture() {
+				h.captureResponse(next, r)
+			}
+
+			h.writeCachedResponse(w)
+		})
+	}
+}
+
+type cacheHandler struct {
+	sync.RWMutex
+
+	duration time.Duration
+	lastTick time.Time
+	writer   *cacheWriter
+}
+
+func (h *cacheHandler) captureResponse(next http.Handler, r *http.Request) {
+	h.Lock()
+	defer h.Unlock()
+
+	h.writer = &cacheWriter{
+		Buffer: bytes.NewBuffer([]byte{}),
+		header: http.Header{},
+	}
+	h.lastTick = time.Now()
+
+	next.ServeHTTP(h.writer, r)
+}
+
+func (h *cacheHandler) writeCachedResponse(w http.ResponseWriter) {
+	h.RLock()
+	defer h.RUnlock()
+
+	for hk, hvs := range h.writer.header {
+		for _, hv := range hvs {
+			w.Header().Add(hk, hv)
+		}
+	}
+
+	if h.writer.statusCodeSet {
+		w.WriteHeader(h.writer.statusCode)
+	}
+
+	if _, err := w.Write(h.writer.Bytes()); err != nil {
+		panic(err)
+	}
+}
+
+func (h *cacheHandler) shouldCapture() bool {
+	h.RLock()
+	defer h.RUnlock()
+
+	if h.writer == nil {
+		return true
+	}
+
+	return time.Since(h.lastTick) >= h.duration
+}
+
+type cacheWriter struct {
+	*bytes.Buffer
+	header        http.Header
+	statusCodeSet bool
+	statusCode    int
+}
+
+func (h *cacheWriter) Header() http.Header {
+	return h.header
+}
+
+func (h *cacheWriter) WriteHeader(i int) {
+	h.statusCodeSet = true
+	h.statusCode = i
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,62 @@
+package healthz_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/manifoldco/healthz"
+)
+
+func BenchmarkCacheMiddleware(b *testing.B) {
+	b.Run("with long cache", func(b *testing.B) {
+		hdlr := healthz.NewHandlerWithMiddleware(
+			http.NewServeMux(),
+			healthz.CacheMiddleware(time.Minute),
+		)
+		srv := httptest.NewServer(hdlr)
+		defer srv.Close()
+
+		cl := &http.Client{}
+		req, err := http.NewRequest(http.MethodGet, srv.URL+"/_healthz", nil)
+		if err != nil {
+			b.Fatalf("Expected no error, got '%s'", err.Error())
+		}
+
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			rsp, err := cl.Do(req)
+			if err != nil {
+				b.Fatalf("Expected no error, got '%s'", err.Error())
+			}
+			defer rsp.Body.Close()
+		}
+	})
+
+	b.Run("with short cache", func(b *testing.B) {
+		hdlr := healthz.NewHandlerWithMiddleware(
+			http.NewServeMux(),
+			healthz.CacheMiddleware(time.Millisecond),
+		)
+		srv := httptest.NewServer(hdlr)
+		defer srv.Close()
+
+		cl := &http.Client{}
+		req, err := http.NewRequest(http.MethodGet, srv.URL+"/_healthz", nil)
+		if err != nil {
+			b.Fatalf("Expected no error, got '%s'", err.Error())
+		}
+
+		b.ResetTimer()
+
+		for n := 0; n < b.N; n++ {
+			rsp, err := cl.Do(req)
+			if err != nil {
+				b.Fatalf("Expected no error, got '%s'", err.Error())
+			}
+			defer rsp.Body.Close()
+		}
+	})
+}

--- a/server.go
+++ b/server.go
@@ -30,7 +30,7 @@ func NewServer(host string, port int) *Server {
 // middleware to the created `_healthz` endpoint. It is up to the user to call
 // `Server.Shutdown` once the service is shutting down to terminate the server
 // gracefully.
-func NewServerWithMiddleware(host string, port int, mw ...middlewareFunc) *Server {
+func NewServerWithMiddleware(host string, port int, mw ...MiddlewareFunc) *Server {
 	handler := NewHandlerWithMiddleware(http.NewServeMux(), mw...)
 
 	addr := host + ":" + strconv.Itoa(port)


### PR DESCRIPTION
This adds a middleware that caches the health check result for a given duration. It helps prevent flooding of health checks by regulating when we'll re-check our health status ourselves.

This is especially useful in environments where multiple sources check for the application's health at the same time and where the application itself in its turn asks other applications for their status.