### PR TITLE
Implement Degraded functionality.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Integrated the Degraded status
+
+### Changed
+
+- Renamed Result to Status and renamed the values to clearer verbs
+- Changed the interface of the TestFunc to include the Status
+
 ## [1.1.0] - 2018-01-03
 
 ### Added

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -30,8 +30,8 @@ func TestHealthChecks_Custom(t *testing.T) {
 	t.Run("with a failing test", func(t *testing.T) {
 		defer resetTests()
 
-		tstFunc := func(_ context.Context) error {
-			return errors.New("failure")
+		tstFunc := func(_ context.Context) (Status, error) {
+			return Unavailable, errors.New("unavailable")
 		}
 		RegisterTest("custom-failure", tstFunc)
 
@@ -46,19 +46,78 @@ func TestHealthChecks_Custom(t *testing.T) {
 		if ln := len(hc.Tests); ln != 2 {
 			t.Fatalf("Expected '%d' tests, got '%d'", 2, ln)
 		}
-		if hc.Result != Failure {
-			t.Fatalf("Expected result to equal '%s', got '%s'", Failure, hc.Result)
+		if hc.Status != Unavailable {
+			t.Fatalf("Expected result to equal '%s', got '%s'", Unavailable, hc.Status)
 		}
-		if d := string(hc.Tests["custom-failure"].Error); d != string(Failure) {
-			t.Fatalf("Expected custom-failure to equal '%s', got '%s'", string(Failure), d)
+		if d := string(hc.Tests["custom-failure"].Error); d != string(Unavailable) {
+			t.Fatalf("Expected custom-failure to equal '%s', got '%s'", string(Unavailable), d)
+		}
+	})
+
+	t.Run("with a degraded test", func(t *testing.T) {
+		defer resetTests()
+
+		tstFunc := func(_ context.Context) (Status, error) {
+			return Degraded, errors.New("degraded")
+		}
+		RegisterTest("custom-failure", tstFunc)
+
+		hc, sc, err := getHealth()
+
+		if err != nil {
+			t.Fatalf("Expected no error, got '%s'", err.Error())
+		}
+		if sc != http.StatusOK {
+			t.Fatalf("Expected status code to equal '%d', got '%d'", http.StatusOK, sc)
+		}
+		if ln := len(hc.Tests); ln != 2 {
+			t.Fatalf("Expected '%d' tests, got '%d'", 2, ln)
+		}
+		if hc.Status != Degraded {
+			t.Fatalf("Expected result to equal '%s', got '%s'", Degraded, hc.Status)
+		}
+		if d := string(hc.Tests["custom-failure"].Error); d != string(Degraded) {
+			t.Fatalf("Expected custom-failure to equal '%s', got '%s'", string(Degraded), d)
+		}
+	})
+
+	t.Run("with a degraded and unavailable test", func(t *testing.T) {
+		defer resetTests()
+
+		RegisterTest("degraded", func(_ context.Context) (Status, error) {
+			return Degraded, errors.New("degraded")
+		})
+		RegisterTest("unavailable", func(_ context.Context) (Status, error) {
+			return Unavailable, errors.New("unavailable")
+		})
+
+		hc, sc, err := getHealth()
+
+		if err != nil {
+			t.Fatalf("Expected no error, got '%s'", err.Error())
+		}
+		if sc != http.StatusServiceUnavailable {
+			t.Fatalf("Expected status code to equal '%d', got '%d'", http.StatusServiceUnavailable, sc)
+		}
+		if ln := len(hc.Tests); ln != 3 {
+			t.Fatalf("Expected '%d' tests, got '%d'", 3, ln)
+		}
+		if hc.Status != Unavailable {
+			t.Fatalf("Expected result to equal '%s', got '%s'", Unavailable, hc.Status)
+		}
+		if d := string(hc.Tests["degraded"].Error); d != string(Degraded) {
+			t.Fatalf("Expected degraded test to equal '%s', got '%s'", string(Degraded), d)
+		}
+		if d := string(hc.Tests["unavailable"].Error); d != string(Unavailable) {
+			t.Fatalf("Expected unavailable test to equal '%s', got '%s'", string(Unavailable), d)
 		}
 	})
 
 	t.Run("with a passing test", func(t *testing.T) {
 		defer resetTests()
 
-		tstFunc := func(_ context.Context) error {
-			return nil
+		tstFunc := func(_ context.Context) (Status, error) {
+			return Available, nil
 		}
 		RegisterTest("custom-success", tstFunc)
 
@@ -72,8 +131,8 @@ func TestHealthChecks_Custom(t *testing.T) {
 		if ln := len(hc.Tests); ln != 2 {
 			t.Fatalf("Expected '%d' tests, got '%d'", 2, ln)
 		}
-		if hc.Result != Success {
-			t.Fatalf("Expected result to equal '%s', got '%s'", Success, hc.Result)
+		if hc.Status != Available {
+			t.Fatalf("Expected result to equal '%s', got '%s'", Available, hc.Status)
 		}
 	})
 }


### PR DESCRIPTION
This implements the Degraded functionality. Allowing tests to register a
Degraded status (which we've renamed from result).

To be in line with the "degraded" naming and due to the breaking change of
the TestFunc interface, we've renamed the Success and Failure verbs to
respectively "Available" and "Unavailable" which is more in line with the
"Degraded" verb. We've also renamed the "Result" interface name to
"Status" which again reflects these verbs better.