### PR TITLE
Run tests concurrently and with a timeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Integrated the Degraded status
+- Set up a global Timeout to run the health check tests in
 
 ### Changed
 
 - Renamed Result to Status and renamed the values to clearer verbs
 - Changed the interface of the TestFunc to include the Status
+- Tests will now run concurrently instead of sequentially
 
 ## [1.1.0] - 2018-01-03
 


### PR DESCRIPTION
This makes the health checks run concurrently. Allowing a quicker execution
speed.

This is useful for when a certain tests acts slower and could potentially
stagger other tests causing a slower overall response. If an external probe
has a timeout set, this could cause failures whilst in practice it's only a
single test that is slower, not failing.

This also enforces a global health check timeout. Health checks should be
fast, so the default is set to 5 seconds.

By utilising the Deadline context, users downstream can detect this as well
and cancel their workload lower down the chain.