### PR TITLE
Don't log ErrServerClosed during Shutdown

### DIFF
--- a/server.go
+++ b/server.go
@@ -70,7 +70,7 @@ func (s *Server) Start() error {
 func (s *Server) Shutdown(ctx context.Context) {
 	s.logger.Printf("Shutting down health server")
 
-	if err := s.srv.Shutdown(ctx); err != nil {
+	if err := s.srv.Shutdown(ctx); err != nil && err != http.ErrServerClosed {
 		s.logger.Fatalf("Error shutting down: %s", err)
 	}
 


### PR DESCRIPTION
`ErrServerClosed` is an expected error when we kill the server process and so we don't need to log it.